### PR TITLE
Install generic worker as a startup item

### DIFF
--- a/userdata/Manifest/win2012.json
+++ b/userdata/Manifest/win2012.json
@@ -832,6 +832,20 @@
       "Target": "Machine"
     },
     {
+      "ComponentName": "PSTools",
+      "ComponentType": "ZipInstall",
+      "Comment": "Required by TaskCluster Generic Worker",
+      "Url": "https://download.sysinternals.com/files/PSTools.zip",
+      "Destination": "C:\\PSTools"
+    },
+    {
+      "ComponentName": "NSSM",
+      "ComponentType": "ZipInstall",
+      "Comment": "Required by TaskCluster Generic Worker",
+      "Url": "http://www.nssm.cc/release/nssm-2.24.zip",
+      "Destination": "C:\\"
+    },
+    {
       "ComponentName": "GenericWorkerDirectory",
       "ComponentType": "DirectoryCreate",
       "Path": "C:\\generic-worker"
@@ -845,7 +859,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v2.0.0alpha25/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v2.0.0alpha19/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -859,6 +873,31 @@
       ],
       "Source": "https://github.com/taskcluster/livelog/releases/download/v0.0.6/livelog-windows-amd64.exe",
       "Target": "C:\\generic-worker\\livelog.exe"
+    },
+    {
+      "ComponentName": "GenericWorkerInstall",
+      "ComponentType": "CommandRun",
+      "Command": "C:\\generic-worker\\generic-worker.exe",
+      "Arguments": [
+        "install",
+        "--config",
+        "C:\\generic-worker\\generic-worker.config"
+      ],
+      "DependsOn": [
+        {
+          "ComponentType": "ZipInstall",
+          "ComponentName": "PSTools"
+        },
+        {
+          "ComponentType": "ZipInstall",
+          "ComponentName": "NSSM"
+        }
+      ],
+      "Validate": {
+        "PathsExist": [
+          "C:\\generic-worker\\generic-worker.config"
+        ]
+      }
     }
   ]
 }

--- a/userdata/Manifest/win2012.json
+++ b/userdata/Manifest/win2012.json
@@ -832,20 +832,6 @@
       "Target": "Machine"
     },
     {
-      "ComponentName": "PSTools",
-      "ComponentType": "ZipInstall",
-      "Comment": "Required by TaskCluster Generic Worker",
-      "Url": "https://download.sysinternals.com/files/PSTools.zip",
-      "Destination": "C:\\PSTools"
-    },
-    {
-      "ComponentName": "NSSM",
-      "ComponentType": "ZipInstall",
-      "Comment": "Required by TaskCluster Generic Worker",
-      "Url": "http://www.nssm.cc/release/nssm-2.24.zip",
-      "Destination": "C:\\"
-    },
-    {
       "ComponentName": "GenericWorkerDirectory",
       "ComponentType": "DirectoryCreate",
       "Path": "C:\\generic-worker"
@@ -859,7 +845,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v2.0.0alpha19/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v2.0.0alpha31/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -880,22 +866,13 @@
       "Command": "C:\\generic-worker\\generic-worker.exe",
       "Arguments": [
         "install",
+        "startup",
         "--config",
         "C:\\generic-worker\\generic-worker.config"
       ],
-      "DependsOn": [
-        {
-          "ComponentType": "ZipInstall",
-          "ComponentName": "PSTools"
-        },
-        {
-          "ComponentType": "ZipInstall",
-          "ComponentName": "NSSM"
-        }
-      ],
       "Validate": {
         "PathsExist": [
-          "C:\\generic-worker\\generic-worker.config"
+          "C:\\generic-worker\\run-generic-worker.bat"
         ]
       }
     }

--- a/userdata/UserConfig.ps1
+++ b/userdata/UserConfig.ps1
@@ -1,95 +1,31 @@
 Configuration UserConfig {
   Import-DscResource -ModuleName PSDesiredStateConfiguration
-  File LogFolder {
-    Type = 'Directory'
-    DestinationPath = ('{0}\log' -f $env:SystemDrive)
-    Ensure = 'Present'
-  }
-  $username = 'cltbld'
-  try {
-    $password = [regex]::matches((New-Object Net.WebClient).DownloadString('http://169.254.169.254/latest/user-data'), ('(?s)<{0}Password>(.*)</{0}Password>' -f $username)).Groups[1].Value
-  } catch {
-    $password = [Guid]::NewGuid().ToString().Substring(0, 13)
-  }
-  Script UserCreate {
-    GetScript = "@{ UserCreate = $($username) }"
+  Script RootUserCreate {
+    GetScript = { @{ Result = (Get-WMiObject -class Win32_UserAccount | Where { $_.Name -eq 'root' }) } }
     SetScript = {
-      $homedir = New-Item -Path ('{0}\Users' -f $env:SystemDrive) -Name $using:username -ItemType 'Directory'
-      Start-Process 'net' -ArgumentList @('user', $using:username, $cltbldPassword, '/add', '/active:yes', '/expires:never', ('/homedir:{0}' -f $homedir.FullName), ('/profilepath:{0}' -f $homedir.FullName)) -Wait -NoNewWindow -PassThru -RedirectStandardOutput ('{0}\log\{1}.net-user-{2}.stdout.log' -f $env:SystemDrive, [DateTime]::Now.ToString("yyyyMMddHHmmss"), $username) -RedirectStandardError ('{0}\log\{1}.net-user-{2}.stderr.log' -f $env:SystemDrive, [DateTime]::Now.ToString("yyyyMMddHHmmss"), $username)
+      try {
+        $password = [regex]::matches((New-Object Net.WebClient).DownloadString('http://169.254.169.254/latest/user-data'), '(?s)<rootPassword>(.*)</rootPassword>').Groups[1].Value
+      } catch {
+        $password = [Guid]::NewGuid().ToString().Substring(0, 13)
+      }
+      Start-Process 'net' -ArgumentList @('user', 'root', $password, '/ADD', '/active:yes', '/expires:never') -Wait -NoNewWindow -PassThru -RedirectStandardOutput ('{0}\log\{1}.net-user-root.stdout.log' -f $env:SystemDrive, [DateTime]::Now.ToString("yyyyMMddHHmmss")) -RedirectStandardError ('{0}\log\{1}.net-user-root.stderr.log' -f $env:SystemDrive, [DateTime]::Now.ToString("yyyyMMddHHmmss"))
+      Start-Job -ScriptBlock {
 
-      $fsr = [Security.AccessControl.FileSystemRights]"FullControl,Modify,ReadAndExecute,ListDirectory,Read,Write"
-      $if = @([Security.AccessControl.InheritanceFlags]::ContainerInherit,[Security.AccessControl.InheritanceFlags]::ObjectInherit)
-      $pf = [Security.AccessControl.PropagationFlags]::None
-      $act = [Security.AccessControl.AccessControlType]::Allow
-      $account = New-Object Security.Principal.NTAccount ('.\{0}' -f $using:username)
-      $acl = Get-Acl -Path $homedir.FullName
-      $acl.AddAccessRule((New-Object Security.AccessControl.FileSystemAccessRule ($account, $fsr, $if, $pf, $act)))
-      Set-Acl -Path $homedir.FullName -AclObject $acl
+        # ssh authorized_keys
+        New-Item ('{0}\.ssh' -f $env:UserProfile) -type directory -force
+        (New-Object Net.WebClient).DownloadFile('https://raw.githubusercontent.com/MozRelOps/OpenCloudConfig/master/userdata/Configuration/authorized_keys', ('{0}\.ssh\authorized_keys' -f $env:UserProfile))
+        Unblock-File -Path ('{0}\.ssh\authorized_keys' -f $env:UserProfile)
+        
+      } -Credential (New-Object Management.Automation.PSCredential 'root', (ConvertTo-SecureString "$password" -AsPlainText -Force))
+      #& icacls @(('{0}\Users\root' -f $env:SystemDrive), '/T', '/C', '/grant', 'Administrators:(F)')
     }
-    TestScript = { if (Get-WMiObject -class Win32_UserAccount | Where { $_.Name -eq $using:username }) { $true } else { $false } }
+    TestScript = { if (Get-WMiObject -class Win32_UserAccount | Where { $_.Name -eq 'root' }) { $true } else { $false } }
   }
-  Group AdministratorsMembers {
-    DependsOn = '[Script]UserCreate'
+  Group RootAsAdministrator {
+    DependsOn = '[Script]RootUserCreate'
     GroupName = 'Administrators'
     Ensure = 'Present'
-    MembersToInclude = @($username)
-  }
-  Registry AutoAdminLogon {
-    DependsOn = '[Script]UserCreate'
-    Ensure = 'Present'
-    Force = $true
-    Key = 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\WinLogon'
-    ValueName = 'AutoAdminLogon'
-    ValueType = 'Dword'
-    Hex = $true
-    ValueData = '0x00000001'
-  }
-  Registry DefaultDomainName {
-    DependsOn = '[Script]UserCreate'
-    Ensure = 'Present'
-    Force = $true
-    Key = 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\WinLogon'
-    ValueName = 'DefaultDomainName'
-    ValueType = 'String'
-    ValueData = '.'
-  }
-  Registry DefaultPassword {
-    DependsOn = '[Script]UserCreate'
-    Ensure = 'Present'
-    Force = $true
-    Key = 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\WinLogon'
-    ValueName = 'DefaultPassword'
-    ValueType = 'String'
-    ValueData = $password
-  }
-  Registry DefaultUserName {
-    DependsOn = '[Script]UserCreate'
-    Ensure = 'Present'
-    Force = $true
-    Key = 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\WinLogon'
-    ValueName = 'DefaultUserName'
-    ValueType = 'String'
-    ValueData = $username
-  }
-  Registry AutoLogonCount {
-    DependsOn = '[Script]UserCreate'
-    Ensure = 'Present'
-    Force = $true
-    Key = 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\WinLogon'
-    ValueName = 'AutoLogonCount'
-    ValueType = 'Dword'
-    ValueData = '100000'
-  }
-  Script GenericWorkerAutoStart {
-    DependsOn = '[Script]UserCreate'
-    GetScript = { @{ Result = (Test-Path -Path ('C:\Users\{0}\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup\generic-worker.lnk' -f $username) -ErrorAction SilentlyContinue ) } }
-    SetScript = {
-      $sc = (New-Object -ComObject WScript.Shell).CreateShortcut(('C:\Users\{0}\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup\generic-worker.lnk' -f $username))
-      $sc.TargetPath = "C:\generic-worker\generic-worker.exe --config C:\generic-worker\generic-worker.config"
-      $sc.Save()
-    }
-    TestScript = { if (Test-Path -Path ('C:\Users\{0}\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup\generic-worker.lnk' -f $username) -ErrorAction SilentlyContinue ) { $true } else { $false } }
-    Credential = New-Object Management.Automation.PSCredential ($username, (ConvertTo-SecureString $password -AsPlainText -Force))
+    MembersToInclude = 'root'
   }
   Script PowershellProfile {
     GetScript = { @{ Result = (Test-Path -Path ('{0}\Microsoft.PowerShell_profile.ps1' -f $PsHome) -ErrorAction SilentlyContinue ) } }
@@ -99,5 +35,10 @@ Configuration UserConfig {
       #Set-ItemProperty 'HKLM:\Software\Microsoft\Command Processor' -Type 'String' -Name 'AutoRun' -Value 'powershell -NoLogo -NonInteractive'
     }
     TestScript = { if (Test-Path -Path ('{0}\Microsoft.PowerShell_profile.ps1' -f $PsHome) -ErrorAction SilentlyContinue ) { $true } else { $false } }
+  }
+  Group TCWorkersGroupCreate {
+    GroupName = 'TCWorkers'
+    Description = 'TaskCluster Generic Worker disposable builder service accounts'
+    Ensure = 'Present'
   }
 }

--- a/userdata/win2012.ps1
+++ b/userdata/win2012.ps1
@@ -14,14 +14,7 @@ function Run-RemoteDesiredStateConfig {
   . $target
   $mof = ('{0}\{1}' -f $env:Temp, $config)
   Invoke-Expression "$config -OutputPath $mof"
-  $configurationData = @{
-    AllNodes = @(
-      @{ 
-        PSDscAllowPlainTextPassword = $true
-      }
-    )
-  }
-  Start-DscConfiguration -ConfigurationData $configurationData -Path "$mof" -Wait -Verbose -Force
+  Start-DscConfiguration -Path "$mof" -Wait -Verbose -Force
 }
 $logFile = ('{0}\log\{1}.userdata-run.log' -f $env:SystemDrive, [DateTime]::Now.ToString("yyyyMMddHHmmss"))
 New-Item -ItemType Directory -Force -Path ('{0}\log' -f $env:SystemDrive)


### PR DESCRIPTION
Hey @grenade,

I've mostly guessed what I need to do here, in order to update the version of the generic worker from `v2.0.0alpha25` to `v2.0.0alpha31`, and to run the install target (`generic-worker.exe install startup`).

I reverted commit e29a24624f0b80916ec9173ced9db1d33b9f6dff since I *think* that was mostly doing the same things that the new `install startup` steps are doing, e.g.:

* [`install(...)`](https://github.com/taskcluster/generic-worker/blob/v2.0.0alpha31/plat_windows.go#L380-L418)
* [`deployStartup(...)`](https://github.com/taskcluster/generic-worker/blob/v2.0.0alpha31/plat_windows.go#L444-L489)
* [`createOSUserAccountForce(...)`](https://github.com/taskcluster/generic-worker/blob/v2.0.0alpha31/plat_windows.go#L106-L162)

In short, the only changes from how it used to be are:

* Install version `v2.0.0alpha31` instead of `v2.0.0alpha25`
* Add the parameter `startup` to the generic worker `install` command
* When checking if the install was successful, check for `C:\generic-worker\run-generic-worker.bat`
 rather than `C:\generic-worker\generic-worker.config` since the config file is _created on execution_ rather than prepared in advance of the first run.

If these three things should be achieved differently, feel free to completely rewrite my changes. :smile:

Thanks!
Pete
