### PR TITLE
Bug 1279260 - updated version of generic worker to 2.0.0

### DIFF
--- a/userdata/Manifest/win2012.json
+++ b/userdata/Manifest/win2012.json
@@ -956,7 +956,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v2.0.0alpha43/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v2.0.0/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -1026,7 +1026,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 2.0.0alpha43"
+            "Match": "generic-worker 2.0.0"
           }
         ]
       }


### PR DESCRIPTION
This is the first official release of GW which I wanted to make now that it is stable, before we go live.

The changes that will get picked up are:
https://github.com/taskcluster/generic-worker/compare/v2.0.0alpha43...v2.0.0