### PR TITLE
Bug 1283858 - Bumped version of generic worker for win7, win10 and win2012

### DIFF
--- a/userdata/Manifest/win10.json
+++ b/userdata/Manifest/win10.json
@@ -354,7 +354,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v2.0.0/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v3.0.0alpha1/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -424,7 +424,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 2.0.0"
+            "Match": "generic-worker 3.0.0alpha1"
           }
         ]
       }

--- a/userdata/Manifest/win2012.json
+++ b/userdata/Manifest/win2012.json
@@ -924,7 +924,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v2.0.0/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v3.0.0alpha1/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -994,7 +994,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 2.0.0"
+            "Match": "generic-worker 3.0.0alpha1"
           }
         ]
       }

--- a/userdata/Manifest/win7.json
+++ b/userdata/Manifest/win7.json
@@ -349,7 +349,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v2.0.0/generic-worker-windows-386.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v3.0.0alpha1/generic-worker-windows-386.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -419,7 +419,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 2.0.0"
+            "Match": "generic-worker 3.0.0alpha1"
           }
         ]
       }


### PR DESCRIPTION
Note, you'll still need to add the worker type metadata to the worker type definition as described in [bug 1283858](https://bugzilla.mozilla.org/show_bug.cgi?id=1283858#c0).